### PR TITLE
fix the consul alerts panic when reminders folder is empty

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -82,13 +82,13 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/checks/change-threshold":
 				valErr = loadCustomValue(&config.Checks.ChangeThreshold, val, ConfigTypeInt)
 
-			// events config
+				// events config
 			case "consul-alerts/config/events/enabled":
 				valErr = loadCustomValue(&config.Events.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/events/handlers":
 				valErr = loadCustomValue(&config.Events.Handlers, val, ConfigTypeStrArray)
 
-			// email notifier config
+				// email notifier config
 			case "consul-alerts/config/notifiers/email/cluster-name":
 				valErr = loadCustomValue(&config.Notifiers.Email.ClusterName, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/email/template":
@@ -114,13 +114,13 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/email/one-per-node":
 				valErr = loadCustomValue(&config.Notifiers.Email.OnePerNode, val, ConfigTypeBool)
 
-			// log notifier config
+				// log notifier config
 			case "consul-alerts/config/notifiers/log/enabled":
 				valErr = loadCustomValue(&config.Notifiers.Log.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/log/path":
 				valErr = loadCustomValue(&config.Notifiers.Log.Path, val, ConfigTypeString)
 
-			// influxdb notifier config
+				// influxdb notifier config
 			case "consul-alerts/config/notifiers/influxdb/enabled":
 				valErr = loadCustomValue(&config.Notifiers.Influxdb.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/influxdb/host":
@@ -134,7 +134,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/influxdb/series-name":
 				valErr = loadCustomValue(&config.Notifiers.Influxdb.SeriesName, val, ConfigTypeString)
 
-			// slack notfier config
+				// slack notfier config
 			case "consul-alerts/config/notifiers/slack/enabled":
 				valErr = loadCustomValue(&config.Notifiers.Slack.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/slack/cluster-name":
@@ -152,7 +152,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/slack/detailed":
 				valErr = loadCustomValue(&config.Notifiers.Slack.Detailed, val, ConfigTypeBool)
 
-			// mattermost notfier config
+				// mattermost notfier config
 			case "consul-alerts/config/notifiers/mattermost/enabled":
 				valErr = loadCustomValue(&config.Notifiers.Mattermost.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/mattermost/cluster-name":
@@ -170,7 +170,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/mattermost/detailed":
 				valErr = loadCustomValue(&config.Notifiers.Mattermost.Detailed, val, ConfigTypeBool)
 
-			// mattermost webhook notifier config
+				// mattermost webhook notifier config
 			case "consul-alerts/config/notifiers/mattermost-webhook/enabled":
 				valErr = loadCustomValue(&config.Notifiers.MattermostWebhook.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/mattermost-webhook/cluster-name":
@@ -184,7 +184,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/mattermost-webhook/icon-url":
 				valErr = loadCustomValue(&config.Notifiers.MattermostWebhook.IconUrl, val, ConfigTypeString)
 
-			// pager-duty notfier config
+				// pager-duty notfier config
 			case "consul-alerts/config/notifiers/pagerduty/enabled":
 				valErr = loadCustomValue(&config.Notifiers.PagerDuty.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/pagerduty/service-key":
@@ -194,7 +194,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/pagerduty/client-url":
 				valErr = loadCustomValue(&config.Notifiers.PagerDuty.ClientUrl, val, ConfigTypeString)
 
-			// hipchat notfier config
+				// hipchat notfier config
 			case "consul-alerts/config/notifiers/hipchat/enabled":
 				valErr = loadCustomValue(&config.Notifiers.HipChat.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/hipchat/cluster-name":
@@ -208,7 +208,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/hipchat/from":
 				valErr = loadCustomValue(&config.Notifiers.HipChat.From, val, ConfigTypeString)
 
-			// OpsGenie notifier config
+				// OpsGenie notifier config
 			case "consul-alerts/config/notifiers/opsgenie/enabled":
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/opsgenie/cluster-name":
@@ -216,7 +216,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/opsgenie/api-key":
 				valErr = loadCustomValue(&config.Notifiers.OpsGenie.ApiKey, val, ConfigTypeString)
 
-			// AwsSns notifier config
+				// AwsSns notifier config
 			case "consul-alerts/config/notifiers/awssns/cluster-name":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.ClusterName, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/awssns/enabled":
@@ -228,7 +228,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/awssns/template":
 				valErr = loadCustomValue(&config.Notifiers.AwsSns.Template, val, ConfigTypeString)
 
-			// VictorOps notfier config
+				// VictorOps notfier config
 			case "consul-alerts/config/notifiers/victorops/enabled":
 				valErr = loadCustomValue(&config.Notifiers.VictorOps.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/victorops/api-key":
@@ -236,7 +236,7 @@ func (c *ConsulAlertClient) LoadConfig() {
 			case "consul-alerts/config/notifiers/victorops/routing-key":
 				valErr = loadCustomValue(&config.Notifiers.VictorOps.RoutingKey, val, ConfigTypeString)
 
-			// iLert notfier config
+				// iLert notfier config
 			case "consul-alerts/config/notifiers/ilert/enabled":
 				valErr = loadCustomValue(&config.Notifiers.ILert.Enabled, val, ConfigTypeBool)
 			case "consul-alerts/config/notifiers/ilert/api-key":
@@ -301,25 +301,30 @@ func (c *ConsulAlertClient) UpdateCheckData() {
 	kvApi := c.api.KV()
 
 	healths, _, _ := healthApi.State("any", nil)
-	reminderkeys, _, _ := c.api.KV().List("consul-alerts/reminders/", nil)
+	reminderKeys, _, _ := c.api.KV().List("consul-alerts/reminders/", nil)
+	remindersSubsLevel := 4
 
-	for index := range reminderkeys {
+	for index := range reminderKeys {
 		log.Printf("checking for stale reminders")
-		s := strings.Split(reminderkeys[index].Key, "/")
-		node, check := s[2], s[3]
+		s := strings.Split(reminderKeys[index].Key, "/")
 
-		nodecat, _, _ := c.api.Health().Node(node, nil)
-		settodelete := true
+		// check if the consul-alerts/reminders/ folder has sub folders
+		if len(s) >= remindersSubsLevel {
+			node, check := s[2], s[3]
 
-		for j := range nodecat {
-			if nodecat[j].CheckID == check {
-				settodelete = false
-				break
+			nodecat, _, _ := c.api.Health().Node(node, nil)
+			settodelete := true
+
+			for j := range nodecat {
+				if nodecat[j].CheckID == check {
+					settodelete = false
+					break
+				}
 			}
-		}
-		if settodelete {
-			log.Printf("Reminder %s %s needs to be deleted, stale", node, check)
-			c.DeleteReminder(node, check)
+			if settodelete {
+				log.Printf("Reminder %s %s needs to be deleted, stale", node, check)
+				c.DeleteReminder(node, check)
+			}
 		}
 	}
 

--- a/consul/client_test.go
+++ b/consul/client_test.go
@@ -286,3 +286,16 @@ func TestIndividualChangeThreshold(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateCheckDataReminders(t *testing.T) {
+	client, err := testClient()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	clearKVPath(t, client, "consul-alerts/reminders/")
+	client.api.KV().Put(&consulapi.KVPair{
+		Key: "consul-alerts/reminders/"}, nil)
+
+	client.UpdateCheckData()
+}


### PR DESCRIPTION
**Go version:** _go.11.1_
**OS:** _MacOS Mojave_
**Consul Version:** _1.4.2_
**Consul-Alerts Version:** _0.5.0_

**Description:** 

When a user creates manually an empty reminder folder (e.g: `consul-alerts/reminders/` ), the consul-alerts binary simply panics and that panic doesn't recover which would kill the watching process. 

The reason for the panic is, there is no check to see if the reminders folder has some subfolders or not. 

```shell
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/AcalephStorage/consul-alerts/consul.(*ConsulAlertClient).UpdateCheckData(0xc420290000)
	/go/src/github.com/AcalephStorage/consul-alerts/consul/client.go:306 +0xe98
github.com/AcalephStorage/consul-alerts/consul.NewClient(0xc4200cc30e, 0xe, 0xc4200cc3fd, 0x3, 0xc42002653c, 0x2, 0x1b, 0xc420143c88, 0x40d0e5)
	/go/src/github.com/AcalephStorage/consul-alerts/consul/client.go:63 +0x28f
main.daemonMode(0xc4201c0e10)
	/go/src/github.com/AcalephStorage/consul-alerts/consul-alerts.go:144 +0x66e
main.main()
	/go/src/github.com/AcalephStorage/consul-alerts/consul-alerts.go:58 +0xf4
```

